### PR TITLE
Fix build configuration

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -5,6 +5,7 @@ module.exports = {
   webpack: {
     alias: {
       '@': path.resolve(__dirname, 'src'),
+      process: 'process/browser.js',
     },
     configure: {
       resolve: {
@@ -12,12 +13,13 @@ module.exports = {
           "crypto": require.resolve("crypto-browserify"),
           "stream": require.resolve("stream-browserify"),
           "buffer": require.resolve("buffer/"),
+          "process": require.resolve("process/browser.js"),
         },
       },
       plugins: [
         new webpack.ProvidePlugin({
           Buffer: ['buffer', 'Buffer'],
-          process: 'process/browser',
+          process: 'process/browser.js',
         }),
       ],
     },

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { cn } from '@/utils/cn';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'default' | 'primary' | 'secondary' | 'ghost' | 'link';
+  variant?: 'default' | 'primary' | 'secondary' | 'ghost' | 'link' | 'outline';
   size?: 'sm' | 'md' | 'lg';
   isLoading?: boolean;
   fullWidth?: boolean;
@@ -20,6 +20,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       secondary: 'bg-gray-500 text-white hover:bg-gray-600',
       ghost: 'hover:bg-gray-100 hover:text-gray-900',
       link: 'text-primary-600 hover:underline',
+      outline: 'border border-gray-300 hover:bg-gray-50',
     };
 
     const sizes = {


### PR DESCRIPTION
## Summary
- add process polyfills in craco config
- support `outline` button variant for TypeScript

## Testing
- `npm run build`
- `npm start` *(fails to run in this environment because dev server awaits connections)*

------
https://chatgpt.com/codex/tasks/task_e_6848e80a83fc83239fb4c3743d1a5906

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new "outline" style option for buttons, allowing users to select an outlined button variant.
- **Chores**
  - Updated internal configuration for improved consistency in module resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->