### PR TITLE
Change dark theme to red

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -23,8 +23,8 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   ];
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <nav className="fixed top-0 z-50 w-full border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+    <div className="min-h-screen bg-gray-50 dark:bg-red-950">
+      <nav className="fixed top-0 z-50 w-full border-b border-gray-200 bg-white dark:border-red-800 dark:bg-red-900">
         <div className="px-3 py-3 lg:px-5 lg:pl-3">
           <div className="flex items-center justify-between">
             <div className="flex items-center">
@@ -41,7 +41,7 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
         </div>
       </nav>
 
-      <aside className="fixed left-0 top-0 z-40 mt-16 h-screen w-64 border-r border-gray-200 bg-white pt-6 transition-transform dark:border-gray-700 dark:bg-gray-800">
+      <aside className="fixed left-0 top-0 z-40 mt-16 h-screen w-64 border-r border-gray-200 bg-white pt-6 transition-transform dark:border-red-800 dark:bg-red-900">
         <div className="h-full overflow-y-auto px-3 pb-4">
           <ul className="space-y-2 font-medium">
             {navigation.map((item) => {
@@ -51,11 +51,11 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
                 <li key={item.name}>
                   <Link
                     to={item.href}
-                    className={`flex items-center rounded-lg p-2 text-gray-900 hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700 ${
-                      isActive ? 'bg-gray-100 dark:bg-gray-700' : ''
+                    className={`flex items-center rounded-lg p-2 text-gray-900 hover:bg-gray-100 dark:text-white dark:hover:bg-red-800 ${
+                      isActive ? 'bg-gray-100 dark:bg-red-800' : ''
                     }`}
                   >
-                    <Icon className="h-5 w-5 text-gray-500 transition duration-75 dark:text-gray-400" />
+                    <Icon className="h-5 w-5 text-gray-500 transition duration-75 dark:text-red-300" />
                     <span className="ml-3">{item.name}</span>
                   </Link>
                 </li>
@@ -66,7 +66,7 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
       </aside>
 
       <div className="mt-16 p-4 sm:ml-64">
-        <div className="rounded-lg border-2 border-dashed border-gray-200 p-4 dark:border-gray-700">
+        <div className="rounded-lg border-2 border-dashed border-gray-200 p-4 dark:border-red-800">
           {children}
         </div>
       </div>

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -9,12 +9,12 @@ interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
 const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
   ({ className, variant = 'default', size = 'md', ...props }, ref) => {
     const variants = {
-      default: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-100',
+      default: 'bg-gray-100 text-gray-800 dark:bg-red-800 dark:text-red-100',
       primary: 'bg-primary-100 text-primary-800 dark:bg-primary-900 dark:text-primary-100',
       success: 'bg-success-100 text-success-800 dark:bg-success-900 dark:text-success-100',
       warning: 'bg-warning-100 text-warning-800 dark:bg-warning-900 dark:text-warning-100',
       error: 'bg-error-100 text-error-800 dark:bg-error-900 dark:text-error-100',
-      gray: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-100',
+      gray: 'bg-gray-100 text-gray-800 dark:bg-red-800 dark:text-red-100',
     };
 
     const sizes = {

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -13,7 +13,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
         'rounded-lg border shadow-sm',
         variant === 'glass'
           ? 'card-glass'
-          : 'bg-white dark:bg-gray-800',
+          : 'bg-white dark:bg-red-900',
         className
       )}
       {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -10,9 +10,9 @@
   }
 
   .dark {
-    --background: 224 71% 4%;
-    --foreground: 213 31% 91%;
-    --border: 216 34% 17%;
+    --background: 357 30% 10%;
+    --foreground: 0 0% 90%;
+    --border: 357 30% 20%;
   }
 
   * {
@@ -56,7 +56,7 @@
   }
 
   .btn-glass {
-    @apply bg-white/20 backdrop-blur-sm text-gray-900 dark:text-white border border-white/40 dark:border-gray-500 hover:bg-white/30 hover:backdrop-blur-md focus-visible:ring-white/50;
+    @apply bg-white/20 backdrop-blur-sm text-gray-900 dark:text-white border border-white/40 dark:border-red-600 hover:bg-white/30 hover:backdrop-blur-md focus-visible:ring-white/50;
   }
   
   .btn-sm {
@@ -76,7 +76,7 @@
   }
 
   .card-glass {
-    @apply bg-white/30 dark:bg-gray-700/30 backdrop-blur-lg border border-white/50 dark:border-gray-500 shadow-md;
+    @apply bg-white/30 dark:bg-red-800/30 backdrop-blur-lg border border-white/50 dark:border-red-700 shadow-md;
   }
   
   .input {

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -11,7 +11,7 @@ const NotFound: React.FC = () => {
         <CardContent className="pt-6">
           <div className="mb-6">
             <h1 className="mb-2 text-4xl font-bold">404</h1>
-            <p className="text-gray-600 dark:text-gray-400">
+            <p className="text-gray-600 dark:text-red-200">
               Oops! The page you're looking for doesn't exist.
             </p>
           </div>


### PR DESCRIPTION
## Summary
- adjust dark color variables to deep reds
- recolor Layout components for red scheme
- apply red styling for Badge, Card, and NotFound components
- tweak glass button/card styles for red backdrop

## Testing
- `npm run lint`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6849c032b9a88323890a70d36f11373b