### PR TITLE
Add offer edit modal

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { cn } from '@/utils';
+
+interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
+  open: boolean;
+  onClose: () => void;
+}
+
+const Modal: React.FC<ModalProps> = ({ open, onClose, className, children, ...props }) => {
+  if (!open) return null;
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className={cn('bg-white dark:bg-gray-800 rounded-lg shadow-lg w-full max-w-lg', className)}
+        onClick={(e) => e.stopPropagation()}
+        {...props}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Modal;


### PR DESCRIPTION
## Summary
- implement a reusable `Modal` component
- show list of offers and open modal on card click
- allow editing APR and max exposure in the modal

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6849c2e956a0832380f1d03147b1b408